### PR TITLE
NECO-112 added 'v' to the tag version

### DIFF
--- a/RicohAPIMStorage.podspec
+++ b/RicohAPIMStorage.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.license      = "MIT"
   s.author       = "Ricoh Company, Ltd."
 
-  s.source      = { :git => "https://github.com/ricohapi/media-storage-swift.git", :tag => "#{s.version}" }
+  s.source      = { :git => "https://github.com/ricohapi/media-storage-swift.git", :tag => "v#{s.version}" }
   s.source_files  = "Source/*.swift"
 
   s.ios.deployment_target = "9.0"


### PR DESCRIPTION
## Changes
- Modified .podspec
  - Added  'v' to the tag version settings.
## Tests

Cannot test.
Because the pod is not published.
